### PR TITLE
chore: update action and go version (and ignore prerelease for auto update)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,12 @@ updates:
   commit-message:
     prefix: chore
     include: scope
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "02:00"
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: chore
+    include: scope

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -35,7 +35,7 @@ jobs:
           # to the issue
           project-url: https://github.com/orgs/zitadel/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-      - uses: actions-ecosystem/action-add-labels@v1.1.0
+      - uses: actions-ecosystem/action-add-labels@v1.1.3
         if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'staff')}}
         with:
           github_token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           file: ./profile.cov
           name: codecov-go
+          token: ${{ secrets.CODECOV_TOKEN }}
   release:
     runs-on: ubuntu-22.04
     needs: [test]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        go: ['1.19', '1.20', '1.21']
+        go: ['1.19', '1.20', '1.21', '1.22']
     name: Go ${{ matrix.go }} test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - run: go test -race -v -coverprofile=profile.cov ./pkg/...
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: ./profile.cov
           name: codecov-go
@@ -35,9 +35,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Source checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Semantic Release
-      uses: cycjimmy/semantic-release-action@v2
+      uses: cycjimmy/semantic-release-action@v4
       with:
         dry_run: false
         semantic_version: 17.0.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,6 @@ jobs:
       uses: cycjimmy/semantic-release-action@v4
       with:
         dry_run: false
-        semantic_version: 17.0.4
+        semantic_version: 19.0.2
         extra_plugins: |
-          @semantic-release/exec@5.0.0
+          @semantic-release/exec@6.0.3

--- a/.github/workflows/update-zitadel.yml
+++ b/.github/workflows/update-zitadel.yml
@@ -14,7 +14,7 @@ jobs:
     name: update zitadel api
     steps:
       - name: checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: check input tag
         if: ${{github.event_name == 'workflow_dispatch'}}
         id: check-input

--- a/.github/workflows/update-zitadel.yml
+++ b/.github/workflows/update-zitadel.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           repository: zitadel/zitadel
           releases-only: true
+          # ignore prereleases
+          regex: '^v([0-9]+)\.([0-9]+)\.([0-9]+)$'
       - name: set tag
         id: tag
         run: |

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Versions that also build are marked with :warning:.
 |---------|--------------------|
 | <1.19   | :x:                |
 | 1.19    | :warning:          |
-| 1.20    | :white_check_mark: |
+| 1.20    | :warning:          |
 | 1.21    | :white_check_mark: |
+| 1.22    | :white_check_mark: |
 
 ## License
 


### PR DESCRIPTION
This PR updates out-dated actions and adds github-actions to dependabot. Further it adds Go 1.22 to the tests and the automatic build for new ZITADEL releases will ignore prereleases in the future.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
