### PR TITLE
feat(authentication): Add Authenticator config options for session store and session cookie name.

### DIFF
--- a/pkg/authentication/authenticate.go
+++ b/pkg/authentication/authenticate.go
@@ -41,6 +41,20 @@ func WithLogger[T Ctx](logger *slog.Logger) Option[T] {
 	}
 }
 
+// WithSessionStore allows a session store other than [InMemorySessions].
+func WithSessionStore[T Ctx](sessions Sessions[T]) Option[T] {
+	return func(a *Authenticator[T]) {
+		a.sessions = sessions
+	}
+}
+
+// WithSessionCookieName allows a session cookie name other than "zitadel.session".
+func WithSessionCookieName[T Ctx](cookieName string) Option[T] {
+	return func(a *Authenticator[T]) {
+		a.sessionCookieName = cookieName
+	}
+}
+
 func New[T Ctx](ctx context.Context, zitadel *zitadel.Zitadel, encryptionKey string, initAuthentication HandlerInitializer[T], options ...Option[T]) (*Authenticator[T], error) {
 	authN, err := initAuthentication(ctx, zitadel)
 	if err != nil {


### PR DESCRIPTION
## Description

As documented in the [InMemorySessions source](https://github.com/zitadel/zitadel-go/blob/next/pkg/authentication/session.go#L11-L15) (emphasis mine):

> InMemorySessions implements the [Sessions] interface by storing the sessions
> in-memory. ***This is obviously not suitable for production and only meant for testing purposes.***

the default implementation for the session sotre is not suitable for production, thus an alternative session store implementation must be used by the end user. Currently there isn't any option to bring your own session store, so I added this option. I also added an option to change the default cookie name for completeness sake.

I don't know how you run your testing suite so I haven't added any tests yet.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.