### PR TITLE
feat(client): add ability to provide grpc dial options like client interceptors

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,9 +18,31 @@ import (
 	"github.com/zitadel/zitadel-go/v3/pkg/zitadel"
 )
 
-type Client struct {
+type clientOptions struct {
 	initTokenSource TokenSourceInitializer
-	connection      *grpc.ClientConn
+	grpcDialOptions []grpc.DialOption
+}
+
+type Option func(*clientOptions)
+
+// WithAuth allows to set a token source as authorization, e.g. [PAT], resp. provide an authentication mechanism,
+// such as JWT Profile ([JWTAuthentication]) or Password ([PasswordAuthentication]) for service users.
+func WithAuth(initTokenSource TokenSourceInitializer) Option {
+	return func(c *clientOptions) {
+		c.initTokenSource = initTokenSource
+	}
+}
+
+// WithGRPCDialOptions allows to use custom grpc dial options when establishing connection with Zitadel.
+// Multiple calls to WithGRPCDialOptions is allowed, options will be appended.
+func WithGRPCDialOptions(opts ...grpc.DialOption) Option {
+	return func(c *clientOptions) {
+		c.grpcDialOptions = append(c.grpcDialOptions, opts...)
+	}
+}
+
+type Client struct {
+	connection *grpc.ClientConn
 
 	systemService       system.SystemServiceClient
 	adminService        admin.AdminServiceClient
@@ -33,44 +55,40 @@ type Client struct {
 	oidcService         oidc_pb.OIDCServiceClient
 }
 
-type Option func(*Client)
-
-// WithAuth allows to set a token source as authorization, e.g. [PAT], resp. provide an authentication mechanism,
-// such as JWT Profile ([JWTAuthentication]) or Password ([PasswordAuthentication]) for service users.
-func WithAuth(initTokenSource TokenSourceInitializer) Option {
-	return func(c *Client) {
-		c.initTokenSource = initTokenSource
+func New(ctx context.Context, zitadel *zitadel.Zitadel, opts ...Option) (*Client, error) {
+	var options clientOptions
+	for _, o := range opts {
+		o(&options)
 	}
-}
 
-func New(ctx context.Context, zitadel *zitadel.Zitadel, options ...Option) (_ *Client, err error) {
-	c := &Client{}
-	for _, option := range options {
-		option(c)
-	}
 	var source oauth2.TokenSource
-	if c.initTokenSource != nil {
-		source, err = c.initTokenSource(ctx, zitadel.Origin())
+	if options.initTokenSource != nil {
+		var err error
+		source, err = options.initTokenSource(ctx, zitadel.Origin())
 		if err != nil {
 			return nil, err
 		}
 	}
-	err = c.newConnection(ctx, zitadel, source)
+
+	conn, err := newConnection(ctx, zitadel, source)
 	if err != nil {
 		return nil, err
 	}
-	return c, nil
+
+	return &Client{
+		connection: conn,
+	}, nil
 }
 
-func (c *Client) newConnection(
+func newConnection(
 	ctx context.Context,
 	zitadel *zitadel.Zitadel,
 	tokenSource oauth2.TokenSource,
 	opts ...grpc.DialOption,
-) error {
+) (*grpc.ClientConn, error) {
 	transportCreds, err := transportCredentials(zitadel.Domain(), zitadel.IsTLS())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	dialOptions := []grpc.DialOption{
@@ -79,8 +97,7 @@ func (c *Client) newConnection(
 	}
 	dialOptions = append(dialOptions, opts...)
 
-	c.connection, err = grpc.DialContext(ctx, zitadel.Host(), dialOptions...)
-	return err
+	return grpc.DialContext(ctx, zitadel.Host(), dialOptions...)
 }
 
 func (c *Client) SystemService() system.SystemServiceClient {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -70,7 +70,7 @@ func New(ctx context.Context, zitadel *zitadel.Zitadel, opts ...Option) (*Client
 		}
 	}
 
-	conn, err := newConnection(ctx, zitadel, source)
+	conn, err := newConnection(ctx, zitadel, source, options.grpcDialOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -62,15 +62,23 @@ func New(ctx context.Context, zitadel *zitadel.Zitadel, options ...Option) (_ *C
 	return c, nil
 }
 
-func (c *Client) newConnection(ctx context.Context, zitadel *zitadel.Zitadel, tokenSource oauth2.TokenSource) error {
+func (c *Client) newConnection(
+	ctx context.Context,
+	zitadel *zitadel.Zitadel,
+	tokenSource oauth2.TokenSource,
+	opts ...grpc.DialOption,
+) error {
 	transportCreds, err := transportCredentials(zitadel.Domain(), zitadel.IsTLS())
 	if err != nil {
 		return err
 	}
+
 	dialOptions := []grpc.DialOption{
 		grpc.WithTransportCredentials(transportCreds),
 		grpc.WithPerRPCCredentials(&cred{tls: zitadel.IsTLS(), tokenSource: tokenSource}),
 	}
+	dialOptions = append(dialOptions, opts...)
+
 	c.connection, err = grpc.DialContext(ctx, zitadel.Host(), dialOptions...)
 	return err
 }


### PR DESCRIPTION
### Description

This closes #349.

A new client option to add custom grpc dial options to Zitadel client is added.

I understand that #349 is in the product backlog, but since I already need metrics I took liberty and prepared this PR. Let me know if I need to alter my code somehow for this PR to be accepted. Thanks!

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
