### PR TITLE
feat(auth): allow setting external secure

### DIFF
--- a/pkg/authentication/authenticate.go
+++ b/pkg/authentication/authenticate.go
@@ -27,6 +27,7 @@ type Authenticator[T Ctx] struct {
 	sessions          Sessions[T]
 	encryptionKey     string
 	sessionCookieName string
+	externalSecure    bool
 }
 
 // Option allows customization of the [Authenticator] such as logging and more.
@@ -52,6 +53,12 @@ func WithSessionStore[T Ctx](sessions Sessions[T]) Option[T] {
 func WithSessionCookieName[T Ctx](cookieName string) Option[T] {
 	return func(a *Authenticator[T]) {
 		a.sessionCookieName = cookieName
+	}
+}
+
+func WithExternalSecure[T Ctx](externalSecure bool) Option[T] {
+	return func(a *Authenticator[T]) {
+		a.externalSecure = externalSecure
 	}
 }
 
@@ -143,7 +150,7 @@ func (a *Authenticator[T]) Logout(w http.ResponseWriter, req *http.Request) {
 	a.deleteSessionCookie(w)
 
 	proto := "http"
-	if req.TLS != nil {
+	if req.TLS != nil || a.externalSecure {
 		proto = "https"
 	}
 	postLogout := fmt.Sprintf("%s://%s/", proto, req.Host)

--- a/pkg/authentication/authenticate.go
+++ b/pkg/authentication/authenticate.go
@@ -56,6 +56,7 @@ func WithSessionCookieName[T Ctx](cookieName string) Option[T] {
 	}
 }
 
+// WithExternalSecure allows using https redirects when the service is behind a reverse proxy.
 func WithExternalSecure[T Ctx](externalSecure bool) Option[T] {
 	return func(a *Authenticator[T]) {
 		a.externalSecure = externalSecure


### PR DESCRIPTION
This change adds the possibility to set an external secure flag to the Authenticator. This allows creating logout URLs with `https` protocol when the service is behind a reverse proxy.

Closes #285 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
