### PR TITLE
feat: allow changing port and skip TLS verfication

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -96,7 +96,7 @@ func newConnection(
 	tokenSource oauth2.TokenSource,
 	opts ...grpc.DialOption,
 ) (*grpc.ClientConn, error) {
-	transportCreds, err := transportCredentials(zitadel.Domain(), zitadel.IsTLS())
+	transportCreds, err := transportCredentials(zitadel.Domain(), zitadel.IsTLS(), zitadel.IsInsecureSkipVerifyTLS())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zitadel/zitadel.go
+++ b/pkg/zitadel/zitadel.go
@@ -9,16 +9,18 @@ import (
 // This includes authentication, authorization as well as explicit API interaction
 // and is dependent of the provided information and initialization of such.
 type Zitadel struct {
-	domain string
-	port   string
-	tls    bool
+	domain                string
+	port                  string
+	tls                   bool
+	insecureSkipVerifyTLS bool
 }
 
 func New(domain string, options ...Option) *Zitadel {
 	zitadel := &Zitadel{
-		domain: domain,
-		port:   "443",
-		tls:    true,
+		domain:                domain,
+		port:                  "443",
+		tls:                   true,
+		insecureSkipVerifyTLS: false,
 	}
 	for _, option := range options {
 		option(zitadel)
@@ -30,10 +32,19 @@ func New(domain string, options ...Option) *Zitadel {
 type Option func(*Zitadel)
 
 // WithInsecure allows to connect to a ZITADEL instance running without TLS
+// Do not use in production
 func WithInsecure(port string) Option {
 	return func(z *Zitadel) {
 		z.port = port
 		z.tls = false
+	}
+}
+
+// WithInsecureSkipVerifyTLS allows to connect to a ZITADEL instance running with TLS but has an untrusted certificate
+// Do not use in production
+func WithInsecureSkipVerifyTLS() Option {
+	return func(z *Zitadel) {
+		z.insecureSkipVerifyTLS = true
 	}
 }
 
@@ -59,6 +70,10 @@ func (z *Zitadel) Host() string {
 
 func (z *Zitadel) IsTLS() bool {
 	return z.tls
+}
+
+func (z *Zitadel) IsInsecureSkipVerifyTLS() bool {
+	return z.insecureSkipVerifyTLS
 }
 
 func (z *Zitadel) Domain() string {

--- a/pkg/zitadel/zitadel.go
+++ b/pkg/zitadel/zitadel.go
@@ -1,6 +1,9 @@
 package zitadel
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 // Zitadel provides the ability to interact with your ZITADEL instance.
 // This includes authentication, authorization as well as explicit API interaction
@@ -31,6 +34,13 @@ func WithInsecure(port string) Option {
 	return func(z *Zitadel) {
 		z.port = port
 		z.tls = false
+	}
+}
+
+// WithPort allows to connect to a ZITADEL instance running on a different port
+func WithPort(port uint16) Option {
+	return func(z *Zitadel) {
+		z.port = strconv.Itoa(int(port))
 	}
 }
 


### PR DESCRIPTION
Locally testing TLS enabled zitadel instances using zitadel-go is hard. It only allows secure connections with port 443, however, listening on 443 often requires special OS privileges. Also, it doesn't allow skipping TLS verification, for example if zitadel uses a self-signed certificate. 

Two options are added to `pkg/zitadel/zitadel.go` that resolve these issues:
- WithPort
- WithInsecureSkipVerifyTLS

These changes are needed to properly test a TLS enabled helm chart deployment using a self-signed cert https://github.com/zitadel/zitadel-charts/pull/268

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
