### PR TITLE
feat: add presigned jwt support

### DIFF
--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -96,3 +96,15 @@ func ScopeProjectID(projectID string) string {
 func ScopeZitadelAPI() string {
 	return ScopeProjectID(scopeZITADELProjectID)
 }
+
+// PreSignedJWT allows using a pre-signed JWT token for authorization.
+// This is useful when you already have a valid JWT token and don't want the client
+// to generate and sign a new one.
+func PreSignedJWT(token string) TokenSourceInitializer {
+	return func(ctx context.Context, _ string) (oauth2.TokenSource, error) {
+		return oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: token,
+			TokenType:   oidc.BearerToken,
+		}), nil
+	}
+}


### PR DESCRIPTION
This pull request adds support for pre-signed JWTs as an alternative authentication method, fixing a limitation where private keys must be supplied directly. The current approach doesn't work with security hardware like Smartcards or Cloud HSMs where private keys can't be accessed directly. 

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
