### PR TITLE
fix(deps): consolidate duplicate dependabot configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,20 +16,6 @@ updates:
                 patterns:
                     - "*"
                 applies-to: "version-updates"
-    -   package-ecosystem: "gomod"
-        directory: "/"
-        security-updates: true
-        schedule:
-            interval: "weekly"
-        open-pull-requests-limit: 10
-        rebase-strategy: "auto"
-        labels:
-            - "dependencies"
-            - "security"
-        commit-message:
-            prefix: "fix"
-            include: "scope"
-        groups:
             gomod-security-updates:
                 patterns:
                     - "*"
@@ -50,20 +36,6 @@ updates:
                 patterns:
                     - "*"
                 applies-to: "version-updates"
-    -   package-ecosystem: "docker"
-        directory: "/build/zitadel"
-        security-updates: true
-        schedule:
-            interval: "weekly"
-        open-pull-requests-limit: 10
-        rebase-strategy: "auto"
-        labels:
-            - "dependencies"
-            - "security"
-        commit-message:
-            prefix: "fix"
-            include: "scope"
-        groups:
             docker-security-updates:
                 patterns:
                     - "*"
@@ -84,20 +56,6 @@ updates:
                 patterns:
                     - "*"
                 applies-to: "version-updates"
-    -   package-ecosystem: "github-actions"
-        directory: "/"
-        security-updates: true
-        schedule:
-            interval: "weekly"
-        open-pull-requests-limit: 10
-        rebase-strategy: "auto"
-        labels:
-            - "dependencies"
-            - "security"
-        commit-message:
-            prefix: "fix"
-            include: "scope"
-        groups:
             actions-security-updates:
                 patterns:
                     - "*"


### PR DESCRIPTION
Fixes Dependabot configuration validation errors by consolidating duplicate package-ecosystem entries into single update blocks with grouped security and version updates.

- Consolidates 6 separate gomod/docker/github-actions update blocks into 3
- Uses groups with applies-to to handle both security-updates and version-updates
- Resolves "overlapping directories" validation errors
- Maintains weekly update schedule and existing labels/commit prefixes

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
