### PR TITLE
feat: add IsGrantedRoleInProject method for project-scoped role checks

### DIFF
--- a/pkg/authorization/check_test.go
+++ b/pkg/authorization/check_test.go
@@ -130,6 +130,7 @@ type testCtx struct {
 	userID                      string
 	isGrantedRole               bool
 	isGrantedRoleInOrganization bool
+	isGrantedRoleInProject      bool
 	token                       string
 }
 
@@ -174,6 +175,13 @@ func (t *testCtx) IsGrantedRoleInOrganization(_, _ string) bool {
 		return false
 	}
 	return t.isGrantedRoleInOrganization
+}
+
+func (t *testCtx) IsGrantedRoleInProject(_, _, _ string) bool {
+	if t == nil {
+		return false
+	}
+	return t.isGrantedRoleInProject
 }
 
 func TestCheckForEmptyorMalformedToken(t *testing.T) {

--- a/pkg/authorization/context.go
+++ b/pkg/authorization/context.go
@@ -14,6 +14,7 @@ type Ctx interface {
 	OrganizationID() string
 	UserID() string
 	IsGrantedRole(role string) bool
+	IsGrantedRoleInProject(projectID, role, organizationID string) bool
 	IsGrantedRoleInOrganization(role, organizationID string) bool
 	SetToken(token string)
 	GetToken() string

--- a/pkg/authorization/oauth/context.go
+++ b/pkg/authorization/oauth/context.go
@@ -56,11 +56,11 @@ func (c *IntrospectionContext) IsGrantedRoleInOrganization(role, organizationID 
 // IsGrantedRoleInProject checks if the role is granted in the specified project using the
 // `urn:zitadel:iam:org:project:{projectId}:roles` claim format. This is the recommended format
 // per Zitadel's latest standards.
-func (c *IntrospectionContext) IsGrantedRoleInProject(projectID, role string) bool {
+func (c *IntrospectionContext) IsGrantedRoleInProject(projectID, role, organisationID string) bool {
 	if c == nil {
 		return false
 	}
-	organisations := c.checkProjectRoleClaim(projectID, role)
+	organisations := c.checkProjectRoleClaim(projectID, role, organisationID)
 	return len(organisations) > 0
 }
 
@@ -84,7 +84,7 @@ func (c *IntrospectionContext) checkRoleClaim(role string) map[string]interface{
 	return organisations
 }
 
-func (c *IntrospectionContext) checkProjectRoleClaim(projectID, role string) map[string]interface{} {
+func (c *IntrospectionContext) checkProjectRoleClaim(projectID, role, organisationID string) map[string]interface{} {
 	claimKey := "urn:zitadel:iam:org:project:" + projectID + ":roles"
 	roles, ok := c.IntrospectionResponse.Claims[claimKey].(map[string]interface{})
 	if !ok || len(roles) == 0 {
@@ -93,6 +93,12 @@ func (c *IntrospectionContext) checkProjectRoleClaim(projectID, role string) map
 	organisations, ok := roles[role].(map[string]interface{})
 	if !ok {
 		return nil
+	}
+	if organisationID != "" {
+		_, ok := organisations[organisationID]
+		if !ok {
+			return nil
+		}
 	}
 	return organisations
 }


### PR DESCRIPTION
Add support for checking roles in specific projects using the new Zitadel claim format: urn:zitadel:iam:org:project:{projectId}:roles

This addresses Zitadel's recommendation to use project-specific role claims instead of the legacy urn:zitadel:iam:org:project:roles format.

https://zitadel.com/docs/guides/integrate/retrieve-user-roles#retrieve-roles-from-the-userinfo-endpoint
```
In order to stay up-to-date with the latest ZITADEL standards, we recommend that you use the roles from the identifier urn:zitadel:iam:org:project:{projectId}:roles rather than urn:zitadel:iam:org:project:roles. While both identifiers are maintained for backwards compatibility, the format which includes the specific ID represents our more recent model.
```

ℹ️ This is a NON-BREAKING change i.e. existing API is honored and the changes are additive

🚀 This fixes a bug in offline token introspection where role claims checks are being skipped when `authCtx.IsGrantedRole(...)` is used. 


Changes:
- Add IsGrantedRoleInProject method to IntrospectionContext
- Add checkProjectRoleClaim helper method
- Add comprehensive unit tests covering edge cases

The method checks if a role is granted in a specific project by looking up the project-specific claim in the JWT token's claims.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story _(requires user story/ticket link)_
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented
  - No deviations from requirements
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implementedmethod)
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system

