### PR TITLE
fix: introduce DefaultContext alias for better type inference

### DIFF
--- a/pkg/authentication/oidc/authenticate.go
+++ b/pkg/authentication/oidc/authenticate.go
@@ -14,6 +14,8 @@ import (
 	"github.com/zitadel/zitadel-go/v3/pkg/zitadel"
 )
 
+type DefaultContext = UserInfoContext[*oidc.IDTokenClaims, *oidc.UserInfo]
+
 type Ctx[C oidc.IDClaims, S rp.SubjectGetter] interface {
 	authentication.Ctx
 	New() Ctx[C, S]
@@ -64,11 +66,11 @@ func ClientIDSecretAuthentication(clientID, clientSecret, redirectURI string, sc
 // DefaultAuthentication is a short version of [WithCodeFlow[*UserInfoContext[*oidc.IDTokenClaims, *oidc.UserInfo], *oidc.IDTokenClaims, *oidc.UserInfo]]
 // with the client_id, redirectURI and encryptionKey and optional scopes.
 // If no scopes are provided, `"openid", "profile", "email"` will be used.
-func DefaultAuthentication(clientID, redirectURI string, key string, scopes ...string) authentication.HandlerInitializer[*UserInfoContext[*oidc.IDTokenClaims, *oidc.UserInfo]] {
+func DefaultAuthentication(clientID, redirectURI string, key string, scopes ...string) authentication.HandlerInitializer[*DefaultContext] {
 	if len(scopes) == 0 {
 		scopes = []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail}
 	}
-	return WithCodeFlow[*UserInfoContext[*oidc.IDTokenClaims, *oidc.UserInfo], *oidc.IDTokenClaims, *oidc.UserInfo](
+	return WithCodeFlow[*DefaultContext, *oidc.IDTokenClaims, *oidc.UserInfo](
 		PKCEAuthentication(clientID, redirectURI, scopes, httphelper.NewCookieHandler([]byte(key), []byte(key))),
 	)
 }


### PR DESCRIPTION
This commit introduces a `DefaultContext` type alias for the complex generic `UserInfoContext` used in `DefaultAuthentication`. This change allows the Go compiler to correctly unify types when passing `WithXXX` options to `authentication.New`, resolving type inference errors.

Closes #537 

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
