### PR TITLE
feat: enable global custom headers propagation via gRPC and HTTP

### DIFF
--- a/pkg/zitadel/zitadel.go
+++ b/pkg/zitadel/zitadel.go
@@ -2,6 +2,7 @@ package zitadel
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 )
 
@@ -13,6 +14,7 @@ type Zitadel struct {
 	port                  string
 	tls                   bool
 	insecureSkipVerifyTLS bool
+	headers               http.Header
 }
 
 func New(domain string, options ...Option) *Zitadel {
@@ -21,6 +23,7 @@ func New(domain string, options ...Option) *Zitadel {
 		port:                  "443",
 		tls:                   true,
 		insecureSkipVerifyTLS: false,
+		headers:               make(http.Header),
 	}
 	for _, option := range options {
 		option(zitadel)
@@ -55,6 +58,14 @@ func WithPort(port uint16) Option {
 	}
 }
 
+// WithCustomHeader allows to set a custom header (e.g. Host, Proxy-Authorization, etc.)
+// which will be sent with every request (gRPC and HTTP).
+func WithCustomHeader(key, value string) Option {
+	return func(z *Zitadel) {
+		z.headers.Add(key, value)
+	}
+}
+
 // Origin returns the HTTP Origin (schema://hostname[:port]), e.g.
 // https://your-instance.zitadel.cloud
 // https://your-domain.com
@@ -78,6 +89,10 @@ func (z *Zitadel) IsInsecureSkipVerifyTLS() bool {
 
 func (z *Zitadel) Domain() string {
 	return z.domain
+}
+
+func (z *Zitadel) Headers() http.Header {
+	return z.headers
 }
 
 func buildOrigin(hostname string, externalPort string, tls bool) string {


### PR DESCRIPTION
This change introduces the WithCustomHeader option to the Zitadel configuration, allowing users to define headers such as Proxy-Authorization or Host.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
