### PR TITLE
feat: expose generic helper for JWT private key to current valid token

### DIFF
--- a/example/auth/using_jwt_profile/main.go
+++ b/example/auth/using_jwt_profile/main.go
@@ -42,4 +42,13 @@ func main() {
 	}
 
 	log.Printf("Successfully called API: Your organization is %s", resp.GetOrg().GetName())
+
+	// Example: Get a valid token for custom API calls
+	token, err := api.GetValidToken()
+	if err != nil {
+		slog.Error("failed to get valid token", "error", err)
+		os.Exit(1)
+	}
+	log.Printf("Got valid access token (first 20 chars): %s...", token[:min(20, len(token))])
+	log.Println("You can now use this token for custom API calls to endpoints not covered by the SDK")
 }

--- a/pkg/client/client_example_test.go
+++ b/pkg/client/client_example_test.go
@@ -1,0 +1,45 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"github.com/zitadel/zitadel-go/v3/pkg/client"
+	"github.com/zitadel/zitadel-go/v3/pkg/zitadel"
+)
+
+// ExampleClient_GetValidToken demonstrates how to retrieve a valid access token
+// from the client for making custom API calls to endpoints not covered by the SDK.
+func ExampleClient_GetValidToken() {
+	ctx := context.Background()
+
+	// Create a client with JWT profile authentication
+	authOption := client.DefaultServiceUserAuthentication(
+		"path/to/key.json",
+		oidc.ScopeOpenID,
+		client.ScopeZitadelAPI(),
+	)
+
+	api, err := client.New(ctx, zitadel.New("example.zitadel.cloud"), client.WithAuth(authOption))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer api.Close()
+
+	// Get a valid token for custom API calls
+	token, err := api.GetValidToken()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Use the token for custom HTTP requests to ZITADEL endpoints
+	// not covered by the SDK
+	req, _ := http.NewRequest("GET", "https://example.zitadel.cloud/custom/endpoint", nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	// The token will be automatically refreshed by the SDK if expired
+	fmt.Printf("Token retrieved successfully (length: %d)\n", len(token))
+}


### PR DESCRIPTION
This pull request adds a `GetValidToken()` method to the `Client` struct, allowing users to retrieve a valid access token for making custom API calls to ZITADEL endpoints not covered by the SDK. The token is automatically refreshed if expired. This addresses a common use case where developers need to access the raw OAuth2 token while still benefiting from the SDK's token management and refresh logic. The change is fully backward compatible as it only adds a new private field and a new public method without modifying any existing signatures.

Closes #494

### Examples

```go
package main

import (
    "context"
    "fmt"
    "log"
    "net/http"

    "github.com/zitadel/oidc/v3/pkg/oidc"
    "github.com/zitadel/zitadel-go/v3/pkg/client"
    "github.com/zitadel/zitadel-go/v3/pkg/zitadel"
)

func main() {
    ctx := context.Background()

    // Create a client with JWT profile authentication
    api, err := client.New(ctx, zitadel.New("example.zitadel.cloud"),
        client.WithAuth(client.DefaultServiceUserAuthentication(
            "path/to/key.json",
            oidc.ScopeOpenID,
            client.ScopeZitadelAPI(),
        )),
    )
    if err != nil {
        log.Fatal(err)
    }
    defer api.Close()

    // Get a valid token for custom API calls
    token, err := api.GetValidToken()
    if err != nil {
        log.Fatal(err)
    }

    // Use the token for custom HTTP requests to ZITADEL endpoints
    // not covered by the SDK
    req, _ := http.NewRequest("GET", "https://example.zitadel.cloud/custom/endpoint", nil)
    req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))

    // Make the request...
}
```

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
