### PR TITLE
feat: add token exchange support for impersonation and delegation

### DIFF
--- a/pkg/tokenexchange/doc.go
+++ b/pkg/tokenexchange/doc.go
@@ -10,23 +10,26 @@
 // grant type enabled. For impersonation, the actor must have appropriate permissions
 // such as ORG_END_USER_IMPERSONATOR.
 //
-// # Impersonation
+// # Client Authentication
 //
-// Impersonation allows a service account to obtain a token that acts as another user.
-// The service account must have impersonation permissions. You can impersonate by
-// user ID (a ZITADEL-specific extension) or by providing an existing user token:
+// Token exchange requires client authentication. Use [ClientCredentials] for
+// applications configured with a client secret, or [JWTProfile] for applications
+// using JWT assertion authentication:
 //
-//	api, _ := client.New(ctx, z,
-//	    client.WithAuth(client.DefaultServiceUserAuthentication("/path/to/key.json", ...)),
-//	)
-//	actorToken, _ := api.GetValidToken()
+//	auth := tokenexchange.ClientCredentials("client-id", "client-secret")
 //
 //	result, err := tokenexchange.Impersonate(ctx, z,
 //	    "259242039378444290",
 //	    actorToken,
 //	    tokenexchange.SubjectIsUserID(),
+//	    tokenexchange.WithClientAuth(auth),
 //	)
 //
+// # Impersonation
+//
+// Impersonation allows a service account to obtain a token that acts as another user.
+// The service account must have impersonation permissions. You can impersonate by
+// user ID (a ZITADEL-specific extension) or by providing an existing user token.
 // The subject token type is specified using [SubjectIsUserID], [SubjectIsAccessToken],
 // [SubjectIsIDToken], or [SubjectIsJWT]. In ZITADEL, delegation and impersonation are
 // functionally equivalent, both resulting in a token with an `act` claim identifying
@@ -41,10 +44,11 @@
 //	    myAccessToken,
 //	    tokenexchange.SubjectIsAccessToken(),
 //	    tokenexchange.WithScopes("openid"),
+//	    tokenexchange.WithClientAuth(auth),
 //	)
 //
-// Use [WithScopes], [WithAudience], and [WithRequestedTokenType] to customize the
-// exchange request.
+// Use [WithScopes], [WithAudience], [WithResource], and [WithRequestedTokenType] to
+// customize the exchange request.
 //
 // # Creating a Client with the Exchanged Token
 //

--- a/pkg/tokenexchange/options.go
+++ b/pkg/tokenexchange/options.go
@@ -1,0 +1,169 @@
+package tokenexchange
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/zitadel/oidc/v3/pkg/client/tokenexchange"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+)
+
+// UserIDTokenType is a ZITADEL-specific token type that allows impersonation
+// by user ID instead of requiring an existing token for the user.
+// This is an experimental ZITADEL extension and may not be supported by
+// other OAuth 2.0 providers.
+const UserIDTokenType oidc.TokenType = "urn:zitadel:params:oauth:token-type:user_id"
+
+type config struct {
+	subjectTokenType   oidc.TokenType
+	actorTokenType     oidc.TokenType
+	scopes             []string
+	audience           []string
+	resource           []string
+	requestedTokenType oidc.TokenType
+	clientAuth         ClientAuth
+}
+
+// Option configures a token exchange request.
+type Option func(*config)
+
+// ClientAuth provides client authentication for token exchange requests.
+// Use [ClientCredentials] or [JWTProfile] to create an instance.
+type ClientAuth interface {
+	createExchanger(ctx context.Context, issuer string, httpClient *http.Client) (tokenexchange.TokenExchanger, error)
+}
+
+type clientCredentialsAuth struct {
+	clientID     string
+	clientSecret string
+}
+
+func (c *clientCredentialsAuth) createExchanger(ctx context.Context, issuer string, httpClient *http.Client) (tokenexchange.TokenExchanger, error) {
+	return tokenexchange.NewTokenExchangerClientCredentials(
+		ctx,
+		issuer,
+		c.clientID,
+		c.clientSecret,
+		tokenexchange.WithHTTPClient(httpClient),
+	)
+}
+
+// ClientCredentials returns a ClientAuth that uses client_id and client_secret
+// for authentication via HTTP Basic Auth.
+func ClientCredentials(clientID, clientSecret string) ClientAuth {
+	return &clientCredentialsAuth{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+	}
+}
+
+type jwtProfileAuth struct {
+	clientID string
+	signer   jose.Signer
+}
+
+func (j *jwtProfileAuth) createExchanger(ctx context.Context, issuer string, httpClient *http.Client) (tokenexchange.TokenExchanger, error) {
+	return tokenexchange.NewTokenExchangerJWTProfile(
+		ctx,
+		issuer,
+		j.clientID,
+		j.signer,
+		tokenexchange.WithHTTPClient(httpClient),
+	)
+}
+
+// JWTProfile returns a ClientAuth that uses JWT assertion for authentication.
+// The signer should be created from the application's private key.
+func JWTProfile(clientID string, signer jose.Signer) ClientAuth {
+	return &jwtProfileAuth{
+		clientID: clientID,
+		signer:   signer,
+	}
+}
+
+// WithClientAuth sets the client authentication method for the token exchange.
+// Token exchange requests require client authentication. Use [ClientCredentials]
+// or [JWTProfile] to create the auth provider.
+func WithClientAuth(auth ClientAuth) Option {
+	return func(cfg *config) {
+		cfg.clientAuth = auth
+	}
+}
+
+// SubjectIsUserID indicates the subject token is a ZITADEL user ID.
+// This is a ZITADEL-specific extension that allows impersonation without
+// requiring an existing token for the target user.
+func SubjectIsUserID() Option {
+	return func(cfg *config) {
+		cfg.subjectTokenType = UserIDTokenType
+	}
+}
+
+// SubjectIsAccessToken indicates the subject token is an access token.
+// This is the default if no subject token type is specified.
+func SubjectIsAccessToken() Option {
+	return func(cfg *config) {
+		cfg.subjectTokenType = oidc.AccessTokenType
+	}
+}
+
+// SubjectIsIDToken indicates the subject token is an ID token.
+func SubjectIsIDToken() Option {
+	return func(cfg *config) {
+		cfg.subjectTokenType = oidc.IDTokenType
+	}
+}
+
+// SubjectIsJWT indicates the subject token is a self-signed JWT.
+func SubjectIsJWT() Option {
+	return func(cfg *config) {
+		cfg.subjectTokenType = oidc.JWTTokenType
+	}
+}
+
+// ActorIsAccessToken indicates the actor token is an access token.
+// This is the default if no actor token type is specified.
+func ActorIsAccessToken() Option {
+	return func(cfg *config) {
+		cfg.actorTokenType = oidc.AccessTokenType
+	}
+}
+
+// ActorIsIDToken indicates the actor token is an ID token.
+func ActorIsIDToken() Option {
+	return func(cfg *config) {
+		cfg.actorTokenType = oidc.IDTokenType
+	}
+}
+
+// WithScopes sets the scopes to request for the exchanged token.
+func WithScopes(scopes ...string) Option {
+	return func(cfg *config) {
+		cfg.scopes = scopes
+	}
+}
+
+// WithAudience sets the audience for the exchanged token.
+func WithAudience(audiences ...string) Option {
+	return func(cfg *config) {
+		cfg.audience = audiences
+	}
+}
+
+// WithResource sets the resource parameter for the exchanged token.
+// This indicates the target service or API where the token will be used.
+func WithResource(resources ...string) Option {
+	return func(cfg *config) {
+		cfg.resource = resources
+	}
+}
+
+// WithRequestedTokenType sets the type of token to request.
+// Use oidc.AccessTokenType for an opaque access token (default),
+// or oidc.JWTTokenType for a JWT access token.
+func WithRequestedTokenType(tokenType oidc.TokenType) Option {
+	return func(cfg *config) {
+		cfg.requestedTokenType = tokenType
+	}
+}

--- a/pkg/tokenexchange/tokenexchange.go
+++ b/pkg/tokenexchange/tokenexchange.go
@@ -6,121 +6,24 @@ import (
 
 	"github.com/zitadel/oidc/v3/pkg/client/tokenexchange"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
-	"github.com/zitadel/zitadel-go/v3/pkg/tokenexchange/internal/http"
+	httputil "github.com/zitadel/zitadel-go/v3/pkg/tokenexchange/internal/http"
 	"github.com/zitadel/zitadel-go/v3/pkg/zitadel"
 )
 
-// UserIDTokenType is a ZITADEL-specific token type that allows impersonation
-// by user ID instead of requiring an existing token for the user.
-const UserIDTokenType oidc.TokenType = "urn:zitadel:params:oauth:token-type:user_id"
-
 // Result contains the tokens returned from a token exchange.
 type Result struct {
-	// AccessToken is the exchanged access token. Depending on WithRequestedTokenType,
-	// this may be an opaque token or a JWT.
-	AccessToken string
-
-	// TokenType is the type of the access token, typically "Bearer".
-	// May be "N_A" if the requested token type was an ID token.
-	TokenType string
-
-	// IDToken is the ID token, only present if "openid" scope was requested.
-	IDToken string
-
-	// RefreshToken is the refresh token, only present if "offline_access" scope was requested.
+	AccessToken  string
+	TokenType    string
+	IDToken      string
 	RefreshToken string
-
-	// ExpiresIn is the lifetime of the access token in seconds.
-	ExpiresIn int
-
-	// Scopes are the scopes granted to the access token.
-	Scopes []string
-}
-
-type config struct {
-	subjectTokenType   oidc.TokenType
-	actorTokenType     oidc.TokenType
-	scopes             []string
-	audience           []string
-	requestedTokenType oidc.TokenType
-}
-
-// Option configures a token exchange request.
-type Option func(*config)
-
-// SubjectIsUserID indicates the subject token is a ZITADEL user ID.
-// This is a ZITADEL-specific extension that allows impersonation without
-// requiring an existing token for the target user.
-func SubjectIsUserID() Option {
-	return func(c *config) {
-		c.subjectTokenType = UserIDTokenType
-	}
-}
-
-// SubjectIsAccessToken indicates the subject token is an access token.
-// This is the default if no subject token type is specified.
-func SubjectIsAccessToken() Option {
-	return func(c *config) {
-		c.subjectTokenType = oidc.AccessTokenType
-	}
-}
-
-// SubjectIsIDToken indicates the subject token is an ID token.
-func SubjectIsIDToken() Option {
-	return func(c *config) {
-		c.subjectTokenType = oidc.IDTokenType
-	}
-}
-
-// SubjectIsJWT indicates the subject token is a self-signed JWT.
-// This is typically used with JWT Profile client authentication.
-func SubjectIsJWT() Option {
-	return func(c *config) {
-		c.subjectTokenType = oidc.JWTTokenType
-	}
-}
-
-// ActorIsAccessToken indicates the actor token is an access token.
-// This is the default if no actor token type is specified.
-func ActorIsAccessToken() Option {
-	return func(c *config) {
-		c.actorTokenType = oidc.AccessTokenType
-	}
-}
-
-// ActorIsIDToken indicates the actor token is an ID token.
-func ActorIsIDToken() Option {
-	return func(c *config) {
-		c.actorTokenType = oidc.IDTokenType
-	}
-}
-
-// WithScopes sets the scopes to request for the exchanged token.
-// Common scopes include "openid", "profile", "email", "offline_access".
-func WithScopes(scopes ...string) Option {
-	return func(c *config) {
-		c.scopes = scopes
-	}
-}
-
-// WithAudience sets the audience for the exchanged token.
-// The audience must be a subset of the combined audiences from subject and actor tokens.
-func WithAudience(audiences ...string) Option {
-	return func(c *config) {
-		c.audience = audiences
-	}
-}
-
-// WithRequestedTokenType sets the type of token to request.
-// Use oidc.AccessTokenType for an opaque access token (default),
-// or oidc.JWTTokenType for a JWT access token.
-func WithRequestedTokenType(tokenType oidc.TokenType) Option {
-	return func(c *config) {
-		c.requestedTokenType = tokenType
-	}
+	ExpiresIn    int
+	Scopes       []string
 }
 
 // Impersonate performs a token exchange to act as another user.
+//
+// Client authentication is required. Use [WithClientAuth] with either
+// [ClientCredentials] or [JWTProfile].
 //
 // The actorToken must be from a user or service account that has impersonation
 // permissions (e.g., ORG_END_USER_IMPERSONATOR or IAM_END_USER_IMPERSONATOR role).
@@ -131,16 +34,6 @@ func WithRequestedTokenType(tokenType oidc.TokenType) Option {
 //   - SubjectIsAccessToken(): subject is an access token
 //   - SubjectIsIDToken(): subject is an ID token
 //   - SubjectIsJWT(): subject is a self-signed JWT
-//
-// Example:
-//
-//	result, err := tokenexchange.Impersonate(ctx,
-//	    z,
-//	    "259242039378444290",
-//	    actorToken,
-//	    tokenexchange.SubjectIsUserID(),
-//	    tokenexchange.WithScopes("openid", "profile"),
-//	)
 func Impersonate(
 	ctx context.Context,
 	z *zitadel.Zitadel,
@@ -161,6 +54,10 @@ func Impersonate(
 	}
 	for _, opt := range opts {
 		opt(cfg)
+	}
+
+	if cfg.clientAuth == nil {
+		return nil, errors.New("tokenexchange: client authentication is required; use WithClientAuth")
 	}
 
 	return doExchange(ctx, z, subjectToken, cfg.subjectTokenType, actorToken, cfg.actorTokenType, cfg)
@@ -186,28 +83,13 @@ func Delegate(
 
 // Exchange performs a simple token exchange without impersonation.
 //
+// Client authentication is required. Use [WithClientAuth] with either
+// [ClientCredentials] or [JWTProfile].
+//
 // Use this to:
 //   - Reduce the scope of a token
 //   - Reduce the audience of a token
 //   - Convert an opaque token to a JWT (or vice versa)
-//
-// Example - reduce scope:
-//
-//	result, err := tokenexchange.Exchange(ctx,
-//	    z,
-//	    myAccessToken,
-//	    tokenexchange.SubjectIsAccessToken(),
-//	    tokenexchange.WithScopes("openid"),
-//	)
-//
-// Example - convert to JWT:
-//
-//	result, err := tokenexchange.Exchange(ctx,
-//	    z,
-//	    opaqueToken,
-//	    tokenexchange.SubjectIsAccessToken(),
-//	    tokenexchange.WithRequestedTokenType(oidc.JWTTokenType),
-//	)
 func Exchange(
 	ctx context.Context,
 	z *zitadel.Zitadel,
@@ -225,6 +107,10 @@ func Exchange(
 		opt(cfg)
 	}
 
+	if cfg.clientAuth == nil {
+		return nil, errors.New("tokenexchange: client authentication is required; use WithClientAuth")
+	}
+
 	return doExchange(ctx, z, subjectToken, cfg.subjectTokenType, "", "", cfg)
 }
 
@@ -237,23 +123,21 @@ func doExchange(
 	actorTokenType oidc.TokenType,
 	cfg *config,
 ) (*Result, error) {
-	te, err := tokenexchange.NewTokenExchanger(
-		ctx,
-		z.Origin(),
-		tokenexchange.WithHTTPClient(http.NewClient(z)),
-	)
+	httpClient := httputil.NewClient(z)
+
+	exchanger, err := cfg.clientAuth.createExchanger(ctx, z.Origin(), httpClient)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := tokenexchange.ExchangeToken(
 		ctx,
-		te,
+		exchanger,
 		subjectToken,
 		subjectTokenType,
 		actorToken,
 		actorTokenType,
-		nil,
+		cfg.resource,
 		cfg.audience,
 		cfg.scopes,
 		cfg.requestedTokenType,

--- a/pkg/tokenexchange/tokenexchange_test.go
+++ b/pkg/tokenexchange/tokenexchange_test.go
@@ -2,11 +2,15 @@ package tokenexchange
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -90,47 +94,101 @@ func TestRequestOptions(t *testing.T) {
 		assert.Equal(t, []string{"aud1", "aud2"}, cfg.audience)
 	})
 
+	t.Run("WithResource", func(t *testing.T) {
+		cfg := &config{}
+		WithResource("https://api.example.com")(cfg)
+		assert.Equal(t, []string{"https://api.example.com"}, cfg.resource)
+	})
+
 	t.Run("WithRequestedTokenType", func(t *testing.T) {
 		cfg := &config{}
 		WithRequestedTokenType(oidc.JWTTokenType)(cfg)
 		assert.Equal(t, oidc.JWTTokenType, cfg.requestedTokenType)
 	})
+
+	t.Run("WithClientAuth", func(t *testing.T) {
+		cfg := &config{}
+		auth := ClientCredentials("client-id", "client-secret")
+		WithClientAuth(auth)(cfg)
+		assert.NotNil(t, cfg.clientAuth)
+	})
+}
+
+func TestClientCredentials(t *testing.T) {
+	auth := ClientCredentials("my-client", "my-secret")
+	assert.NotNil(t, auth)
+
+	cca, ok := auth.(*clientCredentialsAuth)
+	require.True(t, ok)
+	assert.Equal(t, "my-client", cca.clientID)
+	assert.Equal(t, "my-secret", cca.clientSecret)
+}
+
+func TestJWTProfile(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: privateKey},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+
+	auth := JWTProfile("my-client", signer)
+	assert.NotNil(t, auth)
+
+	jpa, ok := auth.(*jwtProfileAuth)
+	require.True(t, ok)
+	assert.Equal(t, "my-client", jpa.clientID)
+	assert.NotNil(t, jpa.signer)
 }
 
 func TestImpersonate_Validation(t *testing.T) {
 	ctx := context.Background()
 	z := zitadel.New("example.zitadel.cloud")
+	auth := ClientCredentials("client", "secret")
 
 	t.Run("empty subject token", func(t *testing.T) {
-		result, err := Impersonate(ctx, z, "", "actor-token", SubjectIsUserID())
+		result, err := Impersonate(ctx, z, "", "actor-token", SubjectIsUserID(), WithClientAuth(auth))
 		assert.Nil(t, result)
 		assert.EqualError(t, err, "tokenexchange: subject token is required")
 	})
 
 	t.Run("empty actor token", func(t *testing.T) {
-		result, err := Impersonate(ctx, z, "subject-token", "", SubjectIsUserID())
+		result, err := Impersonate(ctx, z, "subject-token", "", SubjectIsUserID(), WithClientAuth(auth))
 		assert.Nil(t, result)
 		assert.EqualError(t, err, "tokenexchange: actor token is required for impersonation")
+	})
+
+	t.Run("missing client auth", func(t *testing.T) {
+		result, err := Impersonate(ctx, z, "subject-token", "actor-token", SubjectIsUserID())
+		assert.Nil(t, result)
+		assert.EqualError(t, err, "tokenexchange: client authentication is required; use WithClientAuth")
 	})
 }
 
 func TestExchange_Validation(t *testing.T) {
 	ctx := context.Background()
 	z := zitadel.New("example.zitadel.cloud")
+	auth := ClientCredentials("client", "secret")
 
 	t.Run("empty subject token", func(t *testing.T) {
-		result, err := Exchange(ctx, z, "", SubjectIsAccessToken())
+		result, err := Exchange(ctx, z, "", SubjectIsAccessToken(), WithClientAuth(auth))
 		assert.Nil(t, result)
 		assert.EqualError(t, err, "tokenexchange: subject token is required")
+	})
+
+	t.Run("missing client auth", func(t *testing.T) {
+		result, err := Exchange(ctx, z, "subject-token", SubjectIsAccessToken())
+		assert.Nil(t, result)
+		assert.EqualError(t, err, "tokenexchange: client authentication is required; use WithClientAuth")
 	})
 }
 
 func TestDelegate_IsAliasForImpersonate(t *testing.T) {
-	// Delegate should behave identically to Impersonate
 	ctx := context.Background()
 	z := zitadel.New("example.zitadel.cloud")
 
-	// Both should fail with the same validation error
 	_, errImpersonate := Impersonate(ctx, z, "", "actor", SubjectIsUserID())
 	_, errDelegate := Delegate(ctx, z, "", "actor", SubjectIsUserID())
 
@@ -138,7 +196,6 @@ func TestDelegate_IsAliasForImpersonate(t *testing.T) {
 }
 
 func TestImpersonate_Integration(t *testing.T) {
-	// Mock OIDC discovery and token exchange endpoints
 	var receivedRequest struct {
 		GrantType          string
 		SubjectToken       string
@@ -147,7 +204,12 @@ func TestImpersonate_Integration(t *testing.T) {
 		ActorTokenType     string
 		Scope              string
 		Audience           string
+		Resource           string
 		RequestedTokenType string
+	}
+	var receivedAuth struct {
+		Username string
+		Password string
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -161,6 +223,8 @@ func TestImpersonate_Integration(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(discovery)
 
 		case "/oauth/v2/token":
+			receivedAuth.Username, receivedAuth.Password, _ = r.BasicAuth()
+
 			require.NoError(t, r.ParseForm())
 			receivedRequest.GrantType = r.FormValue("grant_type")
 			receivedRequest.SubjectToken = r.FormValue("subject_token")
@@ -169,6 +233,7 @@ func TestImpersonate_Integration(t *testing.T) {
 			receivedRequest.ActorTokenType = r.FormValue("actor_token_type")
 			receivedRequest.Scope = r.FormValue("scope")
 			receivedRequest.Audience = r.FormValue("audience")
+			receivedRequest.Resource = r.FormValue("resource")
 			receivedRequest.RequestedTokenType = r.FormValue("requested_token_type")
 
 			response := map[string]interface{}{
@@ -187,18 +252,18 @@ func TestImpersonate_Integration(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Extract host from server URL (remove http://)
 	host := server.URL[7:]
-
 	ctx := context.Background()
 	z := zitadel.New(host, zitadel.WithInsecure(""))
+	auth := ClientCredentials("test-client", "test-secret")
 
-	t.Run("impersonate by user ID", func(t *testing.T) {
+	t.Run("impersonate by user ID with client credentials", func(t *testing.T) {
 		result, err := Impersonate(ctx, z,
 			"user-123",
 			"actor-token",
 			SubjectIsUserID(),
 			WithScopes("openid", "profile"),
+			WithClientAuth(auth),
 		)
 
 		require.NoError(t, err)
@@ -206,6 +271,8 @@ func TestImpersonate_Integration(t *testing.T) {
 		assert.Equal(t, "Bearer", result.TokenType)
 		assert.Equal(t, 3600, result.ExpiresIn)
 
+		assert.Equal(t, "test-client", receivedAuth.Username)
+		assert.Equal(t, "test-secret", receivedAuth.Password)
 		assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", receivedRequest.GrantType)
 		assert.Equal(t, "user-123", receivedRequest.SubjectToken)
 		assert.Equal(t, string(UserIDTokenType), receivedRequest.SubjectTokenType)
@@ -218,6 +285,7 @@ func TestImpersonate_Integration(t *testing.T) {
 			"user-access-token",
 			"actor-token",
 			SubjectIsAccessToken(),
+			WithClientAuth(auth),
 		)
 
 		require.NoError(t, err)
@@ -230,6 +298,7 @@ func TestImpersonate_Integration(t *testing.T) {
 			"user-id-token",
 			"actor-token",
 			SubjectIsIDToken(),
+			WithClientAuth(auth),
 		)
 
 		require.NoError(t, err)
@@ -243,6 +312,7 @@ func TestImpersonate_Integration(t *testing.T) {
 			"actor-id-token",
 			SubjectIsUserID(),
 			ActorIsIDToken(),
+			WithClientAuth(auth),
 		)
 
 		require.NoError(t, err)
@@ -256,10 +326,24 @@ func TestImpersonate_Integration(t *testing.T) {
 			"actor-token",
 			SubjectIsUserID(),
 			WithRequestedTokenType(oidc.JWTTokenType),
+			WithClientAuth(auth),
 		)
 
 		require.NoError(t, err)
 		assert.Equal(t, string(oidc.JWTTokenType), receivedRequest.RequestedTokenType)
+	})
+
+	t.Run("impersonate with resource", func(t *testing.T) {
+		_, err := Impersonate(ctx, z,
+			"user-123",
+			"actor-token",
+			SubjectIsUserID(),
+			WithResource("https://api.example.com"),
+			WithClientAuth(auth),
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.example.com", receivedRequest.Resource)
 	})
 }
 
@@ -270,6 +354,10 @@ func TestExchange_Integration(t *testing.T) {
 		SubjectTokenType string
 		ActorToken       string
 		Scope            string
+	}
+	var receivedAuth struct {
+		Username string
+		Password string
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -283,6 +371,8 @@ func TestExchange_Integration(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(discovery)
 
 		case "/oauth/v2/token":
+			receivedAuth.Username, receivedAuth.Password, _ = r.BasicAuth()
+
 			require.NoError(t, r.ParseForm())
 			receivedRequest.GrantType = r.FormValue("grant_type")
 			receivedRequest.SubjectToken = r.FormValue("subject_token")
@@ -307,25 +397,125 @@ func TestExchange_Integration(t *testing.T) {
 	defer server.Close()
 
 	host := server.URL[7:]
-
 	ctx := context.Background()
 	z := zitadel.New(host, zitadel.WithInsecure(""))
+	auth := ClientCredentials("test-client", "test-secret")
 
-	t.Run("simple exchange", func(t *testing.T) {
+	t.Run("simple exchange with client credentials", func(t *testing.T) {
 		result, err := Exchange(ctx, z,
 			"my-access-token",
 			SubjectIsAccessToken(),
 			WithScopes("openid"),
+			WithClientAuth(auth),
 		)
 
 		require.NoError(t, err)
 		assert.Equal(t, "exchanged-token", result.AccessToken)
 		assert.Equal(t, "Bearer", result.TokenType)
 
+		assert.Equal(t, "test-client", receivedAuth.Username)
+		assert.Equal(t, "test-secret", receivedAuth.Password)
 		assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", receivedRequest.GrantType)
 		assert.Equal(t, "my-access-token", receivedRequest.SubjectToken)
 		assert.Equal(t, string(oidc.AccessTokenType), receivedRequest.SubjectTokenType)
 		assert.Empty(t, receivedRequest.ActorToken)
+	})
+}
+
+//goland:noinspection HttpUrlsUsage
+func TestJWTProfile_Integration(t *testing.T) {
+	var receivedRequest struct {
+		GrantType            string
+		SubjectToken         string
+		SubjectTokenType     string
+		ClientAssertionType  string
+		ClientAssertion      string
+		ClientID             string
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			discovery := map[string]interface{}{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/oauth/v2/token",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(discovery)
+
+		case "/oauth/v2/token":
+			require.NoError(t, r.ParseForm())
+			receivedRequest.GrantType = r.FormValue("grant_type")
+			receivedRequest.SubjectToken = r.FormValue("subject_token")
+			receivedRequest.SubjectTokenType = r.FormValue("subject_token_type")
+			receivedRequest.ClientAssertionType = r.FormValue("client_assertion_type")
+			receivedRequest.ClientAssertion = r.FormValue("client_assertion")
+			receivedRequest.ClientID = r.FormValue("client_id")
+
+			response := map[string]interface{}{
+				"access_token":      "jwt-profile-token",
+				"token_type":        "Bearer",
+				"expires_in":        3600,
+				"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	host := server.URL[7:]
+	ctx := context.Background()
+	z := zitadel.New(host, zitadel.WithInsecure(""))
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: privateKey},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+
+	auth := JWTProfile("jwt-client-id", signer)
+
+	t.Run("exchange with JWT profile authentication", func(t *testing.T) {
+		result, err := Exchange(ctx, z,
+			"my-access-token",
+			SubjectIsAccessToken(),
+			WithClientAuth(auth),
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, "jwt-profile-token", result.AccessToken)
+		assert.Equal(t, "Bearer", result.TokenType)
+
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", receivedRequest.GrantType)
+		assert.Equal(t, "my-access-token", receivedRequest.SubjectToken)
+		assert.Equal(t, string(oidc.AccessTokenType), receivedRequest.SubjectTokenType)
+		assert.Equal(t, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", receivedRequest.ClientAssertionType)
+		assert.NotEmpty(t, receivedRequest.ClientAssertion)
+		assert.True(t, strings.HasPrefix(receivedRequest.ClientAssertion, "eyJ"), "client assertion should be a JWT")
+	})
+
+	t.Run("impersonate with JWT profile authentication", func(t *testing.T) {
+		result, err := Impersonate(ctx, z,
+			"user-456",
+			"actor-token",
+			SubjectIsUserID(),
+			WithClientAuth(auth),
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, "jwt-profile-token", result.AccessToken)
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", receivedRequest.GrantType)
+		assert.Equal(t, "user-456", receivedRequest.SubjectToken)
+		assert.Equal(t, string(UserIDTokenType), receivedRequest.SubjectTokenType)
+		assert.Equal(t, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", receivedRequest.ClientAssertionType)
+		assert.NotEmpty(t, receivedRequest.ClientAssertion)
 	})
 }
 
@@ -369,8 +559,9 @@ func TestCustomHeaders_Integration(t *testing.T) {
 		zitadel.WithTransportHeader("X-Custom-Header", "custom-value"),
 		zitadel.WithTransportHeader("X-Another-Header", "another-value"),
 	)
+	auth := ClientCredentials("client", "secret")
 
-	_, err := Exchange(ctx, z, "token", SubjectIsAccessToken())
+	_, err := Exchange(ctx, z, "token", SubjectIsAccessToken(), WithClientAuth(auth))
 	require.NoError(t, err)
 
 	assert.Equal(t, "custom-value", receivedHeaders.Get("X-Custom-Header"))


### PR DESCRIPTION
This pull-request adds RFC 8693 OAuth 2.0 Token Exchange support to the SDK, addressing issue #493. The new `tokenexchange` package provides functions for impersonation and delegation, allowing service accounts with appropriate permissions to obtain tokens that act as other users. The implementation leverages the existing `github.com/zitadel/oidc/v3/pkg/client/tokenexchange` library and supports ZITADEL's user ID token type extension for impersonating users by their ID without requiring an existing token. Client authentication is required using either client credentials or JWT profile authentication.

**Examples**

To impersonate a user by their ZITADEL user ID:

```go
auth := tokenexchange.ClientCredentials("client-id", "client-secret")

result, err := tokenexchange.Impersonate(ctx, z,
    "259242039378444290",
    actorToken,
    tokenexchange.SubjectIsUserID(),
    tokenexchange.WithClientAuth(auth),
)
```

To create a client that operates as the impersonated user:

```go
auth := tokenexchange.ClientCredentials("client-id", "client-secret")

result, _ := tokenexchange.Impersonate(ctx, z, userID, actorToken,
    tokenexchange.SubjectIsUserID(),
    tokenexchange.WithClientAuth(auth),
)

impersonatedClient, _ := client.New(ctx, z,
    client.WithAuth(client.PreSignedJWT(result.AccessToken)),
)
```

Closes #493 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
