### PR TITLE
feat: add WithOnAuthenticated option to Authenticator

### DIFF
--- a/pkg/authentication/authenticate.go
+++ b/pkg/authentication/authenticate.go
@@ -38,6 +38,7 @@ type Authenticator[T Ctx] struct {
 	externalSecure        bool
 	useCookieSession      bool
 	postLogoutRedirectURI string
+	onAuthenticated       OnAuthenticatedFunc[T]
 }
 
 // compile-time check that Authenticator implements AuthenticationChecker
@@ -89,6 +90,18 @@ func WithExternalSecure[T Ctx](externalSecure bool) Option[T] {
 func WithPostLogoutRedirectURI[T Ctx](uri string) Option[T] {
 	return func(a *Authenticator[T]) {
 		a.postLogoutRedirectURI = uri
+	}
+}
+
+// OnAuthenticatedFunc is called after a successful OIDC callback,
+// before the session is stored and the user is redirected.
+type OnAuthenticatedFunc[T Ctx] func(ctx context.Context, authCtx T) error
+
+// WithOnAuthenticated registers a hook that is invoked after a successful authentication
+// in the callback. If the hook returns an error, the login is aborted with a 500 status.
+func WithOnAuthenticated[T Ctx](fn OnAuthenticatedFunc[T]) Option[T] {
+	return func(a *Authenticator[T]) {
+		a.onAuthenticated = fn
 	}
 }
 
@@ -144,6 +157,14 @@ func (a *Authenticator[T]) Callback(w http.ResponseWriter, req *http.Request) {
 		a.logger.Error("unable to decrypt state", "state", stateParam)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+
+	if a.onAuthenticated != nil {
+		if err := a.onAuthenticated(req.Context(), authCtx); err != nil {
+			a.logger.Error("on authenticated hook failed", "error", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	redirectURI := state.RequestedURI

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -3,6 +3,7 @@ package authentication_test
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
@@ -217,6 +218,51 @@ func TestCallbackRedirectsToRootOnEmptyURI(t *testing.T) {
 
 	assert.Equal(t, http.StatusFound, rec.Code)
 	assert.Equal(t, "/", rec.Header().Get("Location"))
+}
+
+func TestOnAuthenticated(t *testing.T) {
+	encKey := generateEncryptionKey()
+	handler := &stubHandler{callbackCtx: newAuthContext("user"), encKey: encKey}
+	initHandler := func(_ context.Context, _ *zitadel.Zitadel) (authentication.Handler[testContext], error) {
+		return handler, nil
+	}
+
+	var called bool
+	auth, err := authentication.New(context.Background(), nil, encKey, initHandler,
+		authentication.WithOnAuthenticated(func(_ context.Context, _ testContext) error {
+			called = true
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback", nil)
+	auth.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.True(t, called)
+}
+
+func TestOnAuthenticatedError(t *testing.T) {
+	encKey := generateEncryptionKey()
+	handler := &stubHandler{callbackCtx: newAuthContext("user"), encKey: encKey}
+	initHandler := func(_ context.Context, _ *zitadel.Zitadel) (authentication.Handler[testContext], error) {
+		return handler, nil
+	}
+
+	auth, err := authentication.New(context.Background(), nil, encKey, initHandler,
+		authentication.WithOnAuthenticated(func(_ context.Context, _ testContext) error {
+			return fmt.Errorf("hook failed")
+		}),
+	)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback", nil)
+	auth.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestStateEncryptionError(t *testing.T) {


### PR DESCRIPTION
Add a `WithOnAuthenticated` option to `Authenticator` that allows registering a callback invoked after a successful OIDC authentication. This provides an extension point for running custom logic (e.g. provisioning users, audit logging) without needing to modify the library.
